### PR TITLE
Avoid ScaleFactorWithSystOp in btagHelper.makeBtagRatioReweighting

### DIFF
--- a/btagHelper.py
+++ b/btagHelper.py
@@ -1,7 +1,6 @@
 from bamboo import treefunctions as op
-from bamboo.treeoperations import ScaleFactorWithSystOp
 
-def makeBtagRatioReweighting(jsonFile, numJets , variation="Nominal", systName=None, nameHint=None):
+def makeBtagRatioReweighting(jsonFile, numJets, systName=None, nameHint=None):
     """ Construct a btag ratio for MC, based on the weights in a JSON file
 
     :param btagRatioFile: path of the JSON file with weights (binned in NumJets)
@@ -12,7 +11,9 @@ def makeBtagRatioReweighting(jsonFile, numJets , variation="Nominal", systName=N
     args = op.construct("Parameters", (op.initList("std::initializer_list<{0}>".format(paramVType), paramVType,
         (op.initList(paramVType, "float", (op.extVar("int", "BinningVariable::NumJets"), numJets)),)),))
     wFun = op.define("ILeptonScaleFactor", 'const ScaleFactor <<name>>{{"{0}"}};'.format(jsonFile), nameHint=nameHint)
-    expr = wFun.get(args, op.extVar("int", variation))
-    if systName and variation == "Nominal":
-        expr._parent = ScaleFactorWithSystOp(expr._parent, systName)
-    return expr
+    expr = wFun.get(args, op.extVar("int", "Nominal"))
+    if systName:
+        expr = op.systematic(expr, name=systName,
+                up  =wFun.get(args, op.extVar("int", "Up")),
+                down=wFun.get(args, op.extVar("int", "Down")))
+    return op.defineOnFirstUse(expr)


### PR DESCRIPTION
[cps-cms/bamboo!197](https://gitlab.cern.ch/cp3-cms/bamboo/-/merge_requests/197) removed ScaleFactorWithSystOp (which was a special case of `OpWithSyst`); this PR implements the same change as in [bamboo.scalefactors.ScaleFactor](https://gitlab.cern.ch/cp3-cms/bamboo/-/blob/master/bamboo/scalefactors.py#L103-110) to use `op.systematic` directly.